### PR TITLE
Fix for when working with nested color functions

### DIFF
--- a/lib/convert.js
+++ b/lib/convert.js
@@ -46,7 +46,7 @@ function toRGB (ast) {
     // convert nested color functions
     adjuster.arguments.forEach(function (arg) {
       if (arg.type == 'function' && arg.name == 'color') {
-        arg.value = toRGB(arg.value);
+        arg.value = toRGB(arg);
         arg.type = 'color';
         delete arg.name;
       }

--- a/test/convert.js
+++ b/test/convert.js
@@ -256,6 +256,7 @@ describe('#convert', function () {
   describe('nested color functions', function () {
     it('should convert nested color functions', function () {
       convert('color(rebeccapurple a(-10%)) a(-10%)', 'rgba(102, 51, 153, 0.81)');
+      convert('color(#4C5859 shade(25%)) blend(color(#4C5859 shade(40%)) 20%)', 'rgb(55, 63, 64)');
     });
   });
 


### PR DESCRIPTION
Appears to have been attempting to convert `arg.value`, instead of arg which is undefined until set.

My understanding of the code here is reasonably limited. Was `arg.value` perhaps intentional, and in that case should it be attempting to handle both `arg` and `arg.value` here?

Hope this helps :) Thanks!
