### PR TITLE
Handle hue values below 0 and above 359 degrees properly

### DIFF
--- a/lib/adjusters.js
+++ b/lib/adjusters.js
@@ -124,7 +124,14 @@ function hslwbAdjuster (prop) {
     var mod;
     if (args[0].type == 'modifier') mod = args.shift().value;
     var val = parseFloat(args[0].value, 10);
-    color[prop](modify(color[prop](), val, mod));
+    var amount = modify(color[prop](), val, mod);
+    if (prop == 'hue') {
+      amount = amount % 360;
+      if (amount < 0) {
+        amount += 360;
+      }
+    }
+    color[prop](amount);
   };
 }
 

--- a/test/convert.js
+++ b/test/convert.js
@@ -150,6 +150,14 @@ describe('#convert', function () {
       convert('hsl(34, 50%, 50%) hue(25)', 'rgb(191, 117, 64)');
     });
 
+    it('should set hue greater than 360', function () {
+      convert('hsl(34, 50%, 50%) hue(385)', 'rgb(191, 117, 64)');
+    });
+
+    it('should set hue less than 360', function () {
+      convert('hsl(34, 50%, 50%) hue(-369)', 'rgb(191, 117, 64)');
+    });
+
     it('should add hue', function () {
       convert('hsl(10, 50%, 50%) hue(+ 15)', 'rgb(191, 117, 64)');
     });
@@ -160,6 +168,14 @@ describe('#convert', function () {
 
     it('should multiply hue', function () {
       convert('hsl(10, 50%, 50%) hue(* 2.5)', 'rgb(191, 117, 64)');
+    });
+
+    it('should adjust hue greater than 360', function () {
+      convert('hsl(240, 50%, 50%) hue(+ 240)', 'rgb(64, 191, 64)');
+    });
+
+    it('should adjust negative hue', function () {
+      convert('hsl(120, 50%, 50%) hue(- 240)', 'rgb(64, 64, 191)');
     });
   });
 


### PR DESCRIPTION
According to [W3C CSS color draft](https://drafts.csswg.org/css-color/#typedef-hue) one can specify values both below 0 and above 359 degrees.

> The angle `0deg` represents red (as does `360deg`, `720deg`, etc.)