### PR TITLE
Require space after + and - modifiers

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -61,7 +61,7 @@ function parse (string) {
    */
 
   function modifier () {
-    var m = match(/^([\+\-\*])/);
+    var m = match(/^([\+\-](?= )|\*)/);
     if (!m) return;
     var ret = {};
     ret.type = 'modifier';

--- a/test/convert.js
+++ b/test/convert.js
@@ -150,12 +150,16 @@ describe('#convert', function () {
       convert('hsl(34, 50%, 50%) hue(25)', 'rgb(191, 117, 64)');
     });
 
+    it('should set hue with explicit positive', function () {
+      convert('hsl(34, 50%, 50%) hue(+25)', 'rgb(191, 117, 64)');
+    });
+
     it('should set hue greater than 360', function () {
       convert('hsl(34, 50%, 50%) hue(385)', 'rgb(191, 117, 64)');
     });
 
     it('should set hue less than 360', function () {
-      convert('hsl(34, 50%, 50%) hue(-369)', 'rgb(191, 117, 64)');
+      convert('hsl(34, 50%, 50%) hue(- 369)', 'rgb(191, 117, 64)');
     });
 
     it('should add hue', function () {
@@ -188,7 +192,7 @@ describe('#convert', function () {
       convert('hsl(25, 25%, 50%) saturation(+ 25%)', 'rgb(191, 117, 64)');
     });
 
-    it('should substract saturation', function () {
+    it('should subtract saturation', function () {
       convert('hsl(25, 60%, 50%) saturation(- 10%)', 'rgb(191, 117, 64)');
     });
 
@@ -206,7 +210,7 @@ describe('#convert', function () {
       convert('hsl(25, 50%, 25%) lightness(+ 25%)', 'rgb(191, 117, 64)');
     });
 
-    it('should substract lightness', function () {
+    it('should subtract lightness', function () {
       convert('hsl(25, 50%, 60%) lightness(- 10%)', 'rgb(191, 117, 64)');
     });
 
@@ -220,12 +224,16 @@ describe('#convert', function () {
       convert('hwb(0, 0%, 0%) whiteness(20%)', 'rgb(255, 51, 51)'); // hwb(0, 20%, 0%)
     });
 
-    it('should add whiteness', function () {
-      convert('hwb(0, 75%, 0%) whiteness(+25%)', 'rgb(255, 255, 255)'); // hwb(0, 100%, 0%)
+    it('should set whiteness with explicit positive', function () {
+      convert('hwb(0, 0%, 0%) whiteness(+20%)', 'rgb(255, 51, 51)'); // hwb(0, 20%, 0%)
     });
 
-    it('should substract whiteness', function () {
-      convert('hwb(0, 30%, 0%) whiteness(-10%)', 'rgb(255, 51, 51)'); // hwb(0, 20%, 0%)
+    it('should add whiteness', function () {
+      convert('hwb(0, 75%, 0%) whiteness(+ 25%)', 'rgb(255, 255, 255)'); // hwb(0, 100%, 0%)
+    });
+
+    it('should subtract whiteness', function () {
+      convert('hwb(0, 30%, 0%) whiteness(- 10%)', 'rgb(255, 51, 51)'); // hwb(0, 20%, 0%)
     });
 
     it('should multiply whiteness', function () {
@@ -238,12 +246,16 @@ describe('#convert', function () {
       convert('hwb(0, 0%, 0%) blackness(20%)', 'rgb(204, 0, 0)'); // hwb(0, 0%, 20%)
     });
 
-    it('should add blackness', function () {
-      convert('hwb(0, 0%, 75%) blackness(+25%)', 'rgb(0, 0, 0)'); // hwb(0, 0%, 100%)
+    it('should set blackness with explicit positive', function () {
+      convert('hwb(0, 0%, 0%) blackness(+20%)', 'rgb(204, 0, 0)'); // hwb(0, 0%, 20%)
     });
 
-    it('should substract blackness', function () {
-      convert('hwb(0, 0%, 30%) blackness(-10%)', 'rgb(204, 0, 0)'); // hwb(0, 0%, 20%)
+    it('should add blackness', function () {
+      convert('hwb(0, 0%, 75%) blackness(+ 25%)', 'rgb(0, 0, 0)'); // hwb(0, 0%, 100%)
+    });
+
+    it('should subtract blackness', function () {
+      convert('hwb(0, 0%, 30%) blackness(- 10%)', 'rgb(204, 0, 0)'); // hwb(0, 0%, 20%)
     });
 
     it('should multiply blackness', function () {
@@ -289,7 +301,7 @@ describe('#convert', function () {
 
   describe('nested color functions', function () {
     it('should convert nested color functions', function () {
-      convert('color(rebeccapurple a(-10%)) a(-10%)', 'rgba(102, 51, 153, 0.81)');
+      convert('color(rebeccapurple a(- 10%)) a(- 10%)', 'rgba(102, 51, 153, 0.81)');
       convert('color(#4C5859 shade(25%)) blend(color(#4C5859 shade(40%)) 20%)', 'rgb(55, 63, 64)');
     });
   });

--- a/test/parse.js
+++ b/test/parse.js
@@ -191,7 +191,7 @@ describe('#parse', function () {
   });
 
   it('should parse nested color functions', function () {
-    parse('color(hsl(0, 0%, 93%) l(-5%)) l(+10%)', {
+    parse('color(hsl(0, 0%, 93%) l(- 5%)) l(+ 10%)', {
       type: 'function',
       name: 'color',
       arguments: [
@@ -237,6 +237,95 @@ describe('#parse', function () {
     });
   });
 
+  it('should properly parse modifiers', function () {
+    parse('red a(+ 5%) a(+5%) a(- 5%) a(-5%) a(* 50%) a(*50%)', {
+      type: 'function',
+      name: 'color',
+      arguments: [
+        {
+          type: 'color',
+          value: 'red',
+        },
+        {
+          type: 'function',
+          name: 'a',
+          arguments: [
+            {
+              type: 'modifier',
+              value: '+'
+            },
+            {
+              type: 'number',
+              value: '5%'
+            }
+          ]
+        },
+        {
+          type: 'function',
+          name: 'a',
+          arguments: [
+            {
+              type: 'number',
+              value: '+5%'
+            }
+          ]
+        },
+        {
+          type: 'function',
+          name: 'a',
+          arguments: [
+            {
+              type: 'modifier',
+              value: '-'
+            },
+            {
+              type: 'number',
+              value: '5%'
+            }
+          ]
+        },
+        {
+          type: 'function',
+          name: 'a',
+          arguments: [
+            {
+              type: 'number',
+              value: '-5%'
+            }
+          ]
+        },
+        {
+          type: 'function',
+          name: 'a',
+          arguments: [
+            {
+              type: 'modifier',
+              value: '*'
+            },
+            {
+              type: 'number',
+              value: '50%'
+            }
+          ]
+        },
+        {
+          type: 'function',
+          name: 'a',
+          arguments: [
+            {
+              type: 'modifier',
+              value: '*'
+            },
+            {
+              type: 'number',
+              value: '50%'
+            }
+          ]
+        }
+      ]
+    });
+  })
+
 
   it('should throw on syntax error', function () {
     assert.throws(function () {
@@ -246,7 +335,7 @@ describe('#parse', function () {
 
   it('should throw on syntax error for adjuster', function () {
     assert.throws(function () {
-      color.parse('color(red l(+5%)');
+      color.parse('color(red l(+ 5%)');
     }, /Missing closing parenthese for/);
   });
 


### PR DESCRIPTION
Fixes https://github.com/ianstormtaylor/css-color-function/issues/18

I hate this modifier syntax, BTW.