### PR TITLE
Fixes Tint, Shade, and Contrast Alpha Interference Issue

### DIFF
--- a/lib/adjusters.js
+++ b/lib/adjusters.js
@@ -36,9 +36,19 @@ exports.blackness = exports.b = hslwbAdjuster('blackness');
  */
 
 exports.blend = function (color, args) {
+  // First store the intented alpha value for the color.
+  var targetAlpha = color.alpha();
+
+  // Reset the alpha value to one. This is required because color.mix mixes
+  // the alpha value as well as rgb values. For blend() purposes, that's not
+  // what we want.
+  color.alpha(1);
+
   var other = new Color(args[0].value);
   var percentage = 1 - parseInt(args[1].value, 10) / 100;
-  color.mix(other, percentage);
+
+  // Finally set the alpha value of the mixed color to the target value.
+  color.mix(other, percentage).alpha(targetAlpha);
 };
 
 /**

--- a/lib/adjusters.js
+++ b/lib/adjusters.js
@@ -36,7 +36,6 @@ exports.blackness = exports.b = hslwbAdjuster('blackness');
  */
 
 exports.blend = function (color, args) {
-  // First store the intented alpha value for the color.
   var targetAlpha = color.alpha();
 
   // Reset the alpha value to one. This is required because color.mix mixes
@@ -89,7 +88,11 @@ exports.contrast = function (color, args) {
   var minRatio = 4.5;
   if (color.contrast(max) > minRatio) {
     var min = binarySearchBWContrast(minRatio, color, max);
-    min.mix(max, percentage);
+    var targetMinAlpha = min.alpha();
+    // Set the alpha to 1 to avoid mix()-ing the alpha value.
+    min.alpha(1);
+    // mixes the colors then sets the alpha back to the target alpha.
+    min.mix(max, percentage).alpha(targetMinAlpha);
   }
   color.hwb(min.hwb());
 };

--- a/test/convert.js
+++ b/test/convert.js
@@ -321,11 +321,11 @@ describe('#convert', function () {
 
   describe('contrast with alpha', function () {
     it('should go to white with a dark color and the given alpha', function() {
-      convert('#d51834 a(40%) contrast(90%)', 'rgba(255, 255, 255, 0.4)');
+      convert('black a(40%) contrast(99%)', 'rgba(255, 255, 255, 0.4)');
     });
 
     it('should go to black with a light color and the given alpha', function() {
-      convert('white a(50%) contrast(99%)', 'rgba(0, 0, 0, 0.4)');
+      convert('white a(50%) contrast(99%)', 'rgba(0, 0, 0, 0.5)');
     });
   });
 

--- a/test/convert.js
+++ b/test/convert.js
@@ -319,6 +319,16 @@ describe('#convert', function () {
     });
   });
 
+  describe('contrast with alpha', function () {
+    it('should go to white with a dark color and the given alpha', function() {
+      convert('#d51834 a(40%) contrast(90%)', 'rgba(255, 255, 255, 0.4)');
+    });
+
+    it('should go to black with a light color and the given alpha', function() {
+      convert('white a(50%) contrast(99%)', 'rgba(0, 0, 0, 0.4)');
+    });
+  });
+
   describe('nested color functions', function () {
     it('should convert nested color functions', function () {
       convert('color(rebeccapurple a(- 10%)) a(- 10%)', 'rgba(102, 51, 153, 0.81)');

--- a/test/convert.js
+++ b/test/convert.js
@@ -275,9 +275,29 @@ describe('#convert', function () {
     });
   });
 
+  describe('tint with alpha', function () {
+    it('should blend a color with white and adjust the alpha', function () {
+      convert('red a(40%) tint(50%)', 'rgba(255, 128, 128, 0.4)');
+    });
+
+    it('should blend a color with white and adjust the alpha', function () {
+      convert('red tint(50%) a(20%)', 'rgba(255, 128, 128, 0.2)');
+    });
+  });
+
   describe('shade', function () {
     it('should blend a color with black', function () {
       convert('red shade(50%)', 'rgb(128, 0, 0)');
+    });
+  });
+
+  describe('shade with alpha', function () {
+    it('should blend a color with black and adjust the alpha', function () {
+      convert('red a(40%) shade(50%)', 'rgba(128, 0, 0, 0.4)');
+    });
+
+    it('should blend a color with black and adjust the alpha', function () {
+      convert('red shade(50%) a(25%)', 'rgba(128, 0, 0, 0.25)');
     });
   });
 


### PR DESCRIPTION
**The problem**

The `tint`, `shade`, and `contrast` adjusters incorrectly modify the alpha value of the base color.

_Current results:_
```javascript
convert('red a(40%) tint(50%)') // rgba(255, 204, 204, 0.7)
convert('red a(40%) shade(50%)') // rgba(51, 0, 0, 0.7)
convert('red a(40%) contrast(99%)') // rgba(0, 0, 0, 0.994)
```

_Expected results:_
```javascript
convert('red a(40%) tint(50%)') // rgba(255, 128, 128, 0.4)
convert('red a(40%) shade(50%)') // rgba(128, 0, 0, 0.4)
convert('red a(40%) contrast(99%)') // rgba(0, 0, 0, 0.4)
```

From usage and reading the spec, I expected `tint`, `shade`, and `contrast` to leave the alpha value of the base color as is.

**The cause**

These three adjusters make use of `Color.mix`. Tint and shade do so here https://github.com/ianstormtaylor/css-color-function/blob/master/lib/adjusters.js#L41 and contrast here https://github.com/ianstormtaylor/css-color-function/blob/master/lib/adjusters.js#L82

Looking at Qix-/color, the `mix` method is ported from the Sass `mix` https://github.com/Qix-/color/blob/0.11.3/index.js#L295 According to the Sass docs http://sass-lang.com/documentation/Sass/Script/Functions.html#mix-instance_method the `mix` method mixes color channels and the alpha channel.

> Mixes two colors together. Specifically, takes the average of each of the RGB components, optionally weighted by the given percentage. **The opacity of the colors is also considered when weighting the components.**
(bolding is mine)

Reading through the Color Level 4 spec, it seems like the only adjusters that should modify the alpha value of the base color are `alpha` and `blenda`.

**My solution in this PR**

First, I wrote failing tests for tint, shade, and contrast. A thing to note about both Tint and Shade is that order mattered. If `tint`/`shade` came before `alpha`, the expected result was produced. If `alpha` came first, the unexpected value was produced.

Code changes; What I did in both the `blend` method and within the `contrast` method was hold on to the initial alpha value of the base color. Then set the alpha to `1`, then call `Color.mix`. After the `mix` was complete, set the alpha back to the initial alpha value. 

This ensures `Color.mix` does not attempt to mix an alpha value less than one.

**Background**
I first hit this issue in https://github.com/tylergaw/colorme/issues/3. Found it first in the colorme.io UI just from usage. Fiddled with the adjusters enough and found the pattern. From there, I just followed the thread until I bumped into the `Color.mix` usage.

I have a PR in for colorme pointing it to my branch of css-color-function https://github.com/tylergaw/colorme/pull/6 for now. And that branch is deployed at `https://colorme.io`

Thanks, let me know if there's anything else you want me to tweak.