### PR TITLE
Updates to latest version of debug package

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,6 +1,6 @@
 1.3.2 - October 4, 2017
 -----------------------
-* Fixes Vulnerability - Regular Expression Denial of Service caused by debug package.
+* Fixes Vulnerability - Regular Expression Denial of Service caused by debug package. `#31`
 
 1.3.1 - July 14, 2017
 -----------------------

--- a/History.md
+++ b/History.md
@@ -1,3 +1,7 @@
+1.3.2 - October 4, 2017
+-----------------------
+* Fixes Vulnerability - Regular Expression Denial of Service caused by debug package.
+
 1.3.1 - July 14, 2017
 -----------------------
 * Fixes Tint, Shade, and Contrast Alpha Interference Issue. `#26`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "css-color-function",
   "repository": "git://github.com/ianstormtaylor/css-color-function.git",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "description": "A parser and converter for Tab Atkins's proposed color function in CSS.",
   "keywords": [
@@ -18,7 +18,7 @@
   "dependencies": {
     "balanced-match": "0.1.0",
     "color": "^0.11.0",
-    "debug": "~0.7.4",
+    "debug": "3.1.0",
     "rgb": "~0.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "balanced-match": "0.1.0",
     "color": "^0.11.0",
-    "debug": "3.1.0",
+    "debug": "^3.1.0",
     "rgb": "~0.1.0"
   }
 }


### PR DESCRIPTION
fixes #30 

As described in #30 and the related links, there was a vulnerability in the debug package. This PR updates to the latest 3.1.0 version of that package to avoid that security issue.