### PR TITLE
Reverts Breaking Changes for a Patch Release

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,6 @@
+1.3.3 - October 6, 2017
+* REVERT RELEASE: This removes the changes made in `#19` only for this release. Those changes will be added back and released in a 2.0 because they are breaking changes.
+
 1.3.2 - October 4, 2017
 -----------------------
 * Fixes Vulnerability - Regular Expression Denial of Service caused by debug package. `#31`

--- a/History.md
+++ b/History.md
@@ -1,13 +1,15 @@
-1.3.3 - October 6, 2017
+1.3.3 - October 7, 2017
 -----------------------
 * REVERT RELEASE: This removes the changes made in `#19` only for this release. Those changes will be added back and released in a 2.0 because they are breaking changes.
 
 1.3.2 - October 4, 2017
 -----------------------
+* WARNING: This contains a breaking change in #19. If you need the 1.x series, use 1.3.3. Otherwise, use the 2.x series.
 * Fixes Vulnerability - Regular Expression Denial of Service caused by debug package. `#31`
 
 1.3.1 - July 14, 2017
 -----------------------
+* WARNING: This contains a breaking change in #19. If you need the 1.x series, use 1.3.3. Otherwise, use the 2.x series.
 * Fixes Tint, Shade, and Contrast Alpha Interference Issue. `#26`
 
 1.3.0 - January 5, 2016

--- a/History.md
+++ b/History.md
@@ -1,4 +1,5 @@
 1.3.3 - October 6, 2017
+-----------------------
 * REVERT RELEASE: This removes the changes made in `#19` only for this release. Those changes will be added back and released in a 2.0 because they are breaking changes.
 
 1.3.2 - October 4, 2017

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -61,7 +61,7 @@ function parse (string) {
    */
 
   function modifier () {
-    var m = match(/^([\+\-](?= )|\*)/);
+    var m = match(/^([\+\-\*])/);
     if (!m) return;
     var ret = {};
     ret.type = 'modifier';

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "css-color-function",
   "repository": "git://github.com/ianstormtaylor/css-color-function.git",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "license": "MIT",
   "description": "A parser and converter for Tab Atkins's proposed color function in CSS.",
   "keywords": [

--- a/test/convert.js
+++ b/test/convert.js
@@ -150,16 +150,12 @@ describe('#convert', function () {
       convert('hsl(34, 50%, 50%) hue(25)', 'rgb(191, 117, 64)');
     });
 
-    it('should set hue with explicit positive', function () {
-      convert('hsl(34, 50%, 50%) hue(+25)', 'rgb(191, 117, 64)');
-    });
-
     it('should set hue greater than 360', function () {
       convert('hsl(34, 50%, 50%) hue(385)', 'rgb(191, 117, 64)');
     });
 
     it('should set hue less than 360', function () {
-      convert('hsl(34, 50%, 50%) hue(- 369)', 'rgb(191, 117, 64)');
+      convert('hsl(34, 50%, 50%) hue(-369)', 'rgb(191, 117, 64)');
     });
 
     it('should add hue', function () {
@@ -192,7 +188,7 @@ describe('#convert', function () {
       convert('hsl(25, 25%, 50%) saturation(+ 25%)', 'rgb(191, 117, 64)');
     });
 
-    it('should subtract saturation', function () {
+    it('should substract saturation', function () {
       convert('hsl(25, 60%, 50%) saturation(- 10%)', 'rgb(191, 117, 64)');
     });
 
@@ -210,7 +206,7 @@ describe('#convert', function () {
       convert('hsl(25, 50%, 25%) lightness(+ 25%)', 'rgb(191, 117, 64)');
     });
 
-    it('should subtract lightness', function () {
+    it('should substract lightness', function () {
       convert('hsl(25, 50%, 60%) lightness(- 10%)', 'rgb(191, 117, 64)');
     });
 
@@ -224,16 +220,12 @@ describe('#convert', function () {
       convert('hwb(0, 0%, 0%) whiteness(20%)', 'rgb(255, 51, 51)'); // hwb(0, 20%, 0%)
     });
 
-    it('should set whiteness with explicit positive', function () {
-      convert('hwb(0, 0%, 0%) whiteness(+20%)', 'rgb(255, 51, 51)'); // hwb(0, 20%, 0%)
-    });
-
     it('should add whiteness', function () {
-      convert('hwb(0, 75%, 0%) whiteness(+ 25%)', 'rgb(255, 255, 255)'); // hwb(0, 100%, 0%)
+      convert('hwb(0, 75%, 0%) whiteness(+25%)', 'rgb(255, 255, 255)'); // hwb(0, 100%, 0%)
     });
 
-    it('should subtract whiteness', function () {
-      convert('hwb(0, 30%, 0%) whiteness(- 10%)', 'rgb(255, 51, 51)'); // hwb(0, 20%, 0%)
+    it('should substract whiteness', function () {
+      convert('hwb(0, 30%, 0%) whiteness(-10%)', 'rgb(255, 51, 51)'); // hwb(0, 20%, 0%)
     });
 
     it('should multiply whiteness', function () {
@@ -246,16 +238,12 @@ describe('#convert', function () {
       convert('hwb(0, 0%, 0%) blackness(20%)', 'rgb(204, 0, 0)'); // hwb(0, 0%, 20%)
     });
 
-    it('should set blackness with explicit positive', function () {
-      convert('hwb(0, 0%, 0%) blackness(+20%)', 'rgb(204, 0, 0)'); // hwb(0, 0%, 20%)
-    });
-
     it('should add blackness', function () {
-      convert('hwb(0, 0%, 75%) blackness(+ 25%)', 'rgb(0, 0, 0)'); // hwb(0, 0%, 100%)
+      convert('hwb(0, 0%, 75%) blackness(+25%)', 'rgb(0, 0, 0)'); // hwb(0, 0%, 100%)
     });
 
-    it('should subtract blackness', function () {
-      convert('hwb(0, 0%, 30%) blackness(- 10%)', 'rgb(204, 0, 0)'); // hwb(0, 0%, 20%)
+    it('should substract blackness', function () {
+      convert('hwb(0, 0%, 30%) blackness(-10%)', 'rgb(204, 0, 0)'); // hwb(0, 0%, 20%)
     });
 
     it('should multiply blackness', function () {
@@ -331,7 +319,7 @@ describe('#convert', function () {
 
   describe('nested color functions', function () {
     it('should convert nested color functions', function () {
-      convert('color(rebeccapurple a(- 10%)) a(- 10%)', 'rgba(102, 51, 153, 0.81)');
+      convert('color(rebeccapurple a(-10%)) a(-10%)', 'rgba(102, 51, 153, 0.81)');
       convert('color(#4C5859 shade(25%)) blend(color(#4C5859 shade(40%)) 20%)', 'rgb(55, 63, 64)');
     });
   });

--- a/test/parse.js
+++ b/test/parse.js
@@ -191,7 +191,7 @@ describe('#parse', function () {
   });
 
   it('should parse nested color functions', function () {
-    parse('color(hsl(0, 0%, 93%) l(- 5%)) l(+ 10%)', {
+    parse('color(hsl(0, 0%, 93%) l(-5%)) l(+10%)', {
       type: 'function',
       name: 'color',
       arguments: [
@@ -237,95 +237,6 @@ describe('#parse', function () {
     });
   });
 
-  it('should properly parse modifiers', function () {
-    parse('red a(+ 5%) a(+5%) a(- 5%) a(-5%) a(* 50%) a(*50%)', {
-      type: 'function',
-      name: 'color',
-      arguments: [
-        {
-          type: 'color',
-          value: 'red',
-        },
-        {
-          type: 'function',
-          name: 'a',
-          arguments: [
-            {
-              type: 'modifier',
-              value: '+'
-            },
-            {
-              type: 'number',
-              value: '5%'
-            }
-          ]
-        },
-        {
-          type: 'function',
-          name: 'a',
-          arguments: [
-            {
-              type: 'number',
-              value: '+5%'
-            }
-          ]
-        },
-        {
-          type: 'function',
-          name: 'a',
-          arguments: [
-            {
-              type: 'modifier',
-              value: '-'
-            },
-            {
-              type: 'number',
-              value: '5%'
-            }
-          ]
-        },
-        {
-          type: 'function',
-          name: 'a',
-          arguments: [
-            {
-              type: 'number',
-              value: '-5%'
-            }
-          ]
-        },
-        {
-          type: 'function',
-          name: 'a',
-          arguments: [
-            {
-              type: 'modifier',
-              value: '*'
-            },
-            {
-              type: 'number',
-              value: '50%'
-            }
-          ]
-        },
-        {
-          type: 'function',
-          name: 'a',
-          arguments: [
-            {
-              type: 'modifier',
-              value: '*'
-            },
-            {
-              type: 'number',
-              value: '50%'
-            }
-          ]
-        }
-      ]
-    });
-  })
-
 
   it('should throw on syntax error', function () {
     assert.throws(function () {
@@ -335,7 +246,7 @@ describe('#parse', function () {
 
   it('should throw on syntax error for adjuster', function () {
     assert.throws(function () {
-      color.parse('color(red l(+ 5%)');
+      color.parse('color(red l(+5%)');
     }, /Missing closing parenthese for/);
   });
 


### PR DESCRIPTION
fixes #32 

As noted in that issue breaking changes were made in #19. The idea was to release those in a 2.0, but I missed that and ended up releasing them in 1.3.1.

This PR removes those changes for a quick 1.3.3. This release will include the updates in #26 and #31.